### PR TITLE
Pauls full

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ config/liquibase_cco_full.properties
 src/main/resources/edu/harvard/huh/specify/datamodel/cco_poc/db/specify.6.6.06.sql
 src/main/resources/edu/harvard/huh/specify/datamodel/cco_poc/db/specify_huh.sql
 
+cco_full-dump-*

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,30 @@
+#!make
+
+# timestamp for the database-export
+TS := $(shell date '+%Y_%m_%d_%H_%M')
+
+# credentials for the database
+DB=cco_full
+DB_USER=xxx
+DB_PSW=yyy
+
+copy:
+	@echo "remember to update the credentials in the file before running 'build' "
+	@cp config/liquibase_cco_full.properties.mysqltemplate config/liquibase_cco_full.properties
+
+build:
+	@echo "Running Liquibase ... " 
+	@mvn clean install
+
+clean:
+	@echo "remove... " 
+	@mvn clean 
+
+create_db:
+	mysql -u ${DB_USER} -p${DB_PSW} -e "create database IF NOT EXISTS ${MYSQL_DB};"
+
+drop_db:
+	mysql -u ${DB_USER} -p${DB_PSW} -e "drop database IF EXISTS ${MYSQL_DB};"
+
+dump_db:
+	mysqldump -u ${DB_USER} -p${DB_PSW} ${DB} > ${DB}-dump-$(TS).sql

--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,13 @@ DB=cco_full
 DB_USER=xxx
 DB_PSW=yyy
 
-copy:
+copy-mysql:
 	@echo "remember to update the credentials in the file before running 'build' "
 	@cp config/liquibase_cco_full.properties.mysqltemplate config/liquibase_cco_full.properties
+
+copy-postgreSQL:
+	@echo "remember to update the credentials in the file before running 'build' "
+	@cp config/liquibase_cco_full.properties.postgresqltemplate config/liquibase_cco_full.properties
 
 build:
 	@echo "Running Liquibase ... " 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ config/liquibase_cco_full.properties is in .gitignore and should not be put unde
 
 You *must* copy the config/liquibase_cco_full.properties.mysqltemplate to config/liquibase_cco_full.properties, and then add your credentials to the file.
 
-    $ cp config/liquibase_cco_full.properties.mysqltemplate config/liquibase_cco_full.properties
+    $ make copy-mysql
     $ vim config/liquibase_cco_full.properties
 
 #### For Postgresql
@@ -68,14 +68,15 @@ You *must* copy the config/liquibase_cco_full.properties.mysqltemplate to config
 2. create the schema 'cco_full', check the credentials in the liquibase.postgresql.properties-file
 3. replace liquibase_cco_full.properties with the liquibase_cco_full.properties.postgrestemplate.
 
-    $ cp config/liquibase_cco_full.properties.postgresqltemplate config/liquibase_cco_full.properties
+    $ make copy-postgreSQL
     $ vim config/liquibase_cco_full.properties
 
 ## To build the database with Liquibase
 
-To run the project type '**mvn  clean install**' in the same directory that the pom.xml-file resides.  You must have first met the prerequisites listed above, including creating the database schema and having copied a template to config/liquibase_cco_full.properties and added your database credentials to that file.
+To run the project type '**make build**' in the same directory that the pom.xml-file resides.  You must have first met the prerequisites listed above, including creating the database schema and having copied a template to config/liquibase_cco_full.properties and added your database credentials to that file.
 
-    mvn clean install
+     $ make create_db DB_USER=my-user DB_PSW=my-password
+     $ make build
 
 ## Configuration Files 
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,9 +25,9 @@
     	<version>5.1.37</version>
     </dependency>
     <dependency>
-            <groupId>postgresql</groupId>
-            <artifactId>postgresql</artifactId>
-            <version>9.1-901-1.jdbc4</version>
+      <groupId>postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <version>9.1-901-1.jdbc4</version>
     </dependency>
   </dependencies>
   <build>
@@ -35,7 +35,7 @@
             <plugin>
                 <groupId>org.liquibase</groupId>
                 <artifactId>liquibase-maven-plugin</artifactId>
-                 <version>3.0.5</version> 	
+                 <version>3.5.3</version> 	
                 <executions>
                     <execution>
                         <phase>process-resources</phase>
@@ -50,4 +50,25 @@
             </plugin>
         </plugins>
   </build>
+ <developers>
+        <developer>
+            <id>ingierli</id>
+            <name>Ingimar Erlingsson</name>
+            <email>ingimar.erlingsson@nrm.se</email>
+            <organization>@nrm.se</organization>
+            <roles>
+              <role>developer</role>
+            </roles>
+        </developer>
+        <developer>
+            <id>ingierli</id>
+            <name>Paul J. Morris</name>
+            <email>mole@morris.net</email>
+            <organization>-</organization>
+            <roles>
+              <role>architect</role>
+              <role>developer</role>
+            </roles>
+        </developer> 
+ </developers>
 </project>

--- a/src/main/resources/edu/harvard/huh/specify/datamodel/cco_full/db/db.changelog-master.xml
+++ b/src/main/resources/edu/harvard/huh/specify/datamodel/cco_full/db/db.changelog-master.xml
@@ -4,6 +4,7 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/1.9
          http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd">
-   <include file="edu/harvard/huh/specify/datamodel/cco_full/db/tables.sql"/>
-   <include file="edu/harvard/huh/specify/datamodel/cco_full/db/functions.sql"/>
+   <include file="edu/harvard/huh/specify/datamodel/cco_full/db/tables.sql"/> 
+   <include file="edu/harvard/huh/specify/datamodel/cco_full/db/additional_alter_statements.sql"/>
+   <include file="edu/harvard/huh/specify/datamodel/cco_full/db/exampledata.sql"/>
 </databaseChangeLog>

--- a/src/main/resources/edu/harvard/huh/specify/datamodel/cco_full/db/exampledata.sql
+++ b/src/main/resources/edu/harvard/huh/specify/datamodel/cco_full/db/exampledata.sql
@@ -1,101 +1,83 @@
--- Example data illustrating the use of the cco_full schema.
+-- liquibase formatted sql
+-- @author Paul J. Morris
 
+-- Example data illustrating the use of the cco_full schema.
 -- Real agents (authors, collectors) used in the example data.
 
-insert into agent(agent_id, preferred_name_string,sameas_guid,yearofbirth,yearofdeath,abbreviated_name_string,prefix,suffix,first_name,middle_names,family_names) 
-       values (3,'Mason Ellsworth Hale, Jr.','https://viaf.org/viaf/310661352',1928,1990,'Hale','','Jr.','Mason','Ellsworth','Hale');
+-- changeset chicoreus:insert_agent_related
+insert into agent(agent_id, preferred_name_string,sameas_guid,yearofbirth,yearofdeath,abbreviated_name_string,prefix,suffix,first_name,middle_names,family_names) values (3,'Mason Ellsworth Hale, Jr.','https://viaf.org/viaf/310661352',1928,1990,'Hale','','Jr.','Mason','Ellsworth','Hale');
+
 insert into agentname(agent_id, type, name) values (3,'full name','Mason Ellsworth Hale, Jr.');
 insert into agentname(agent_id, type, name) values (3,'also known as','Mason Hale Jr.');
 insert into agentname(agent_id, type, name) values (3,'standard botanical abbreviation','Hale');
 insert into agentlink (agent_id, type, link, text) values (3,'wiki','https://en.wikipedia.org/wiki/Mason_Ellsworth_Hale','Wikipedia entry');
 
-insert into agent(agent_id, preferred_name_string,sameas_guid,yearofbirth,yearofdeath,abbreviated_name_string,prefix,suffix,first_name,middle_names,family_names) 
-       values (4,'Jakob Friedrich Ehrhart','https://viaf.org/viaf/3221377',1742,1795,'Ehrh.','','','Jakob','Friedrich','Ehrhart');
+insert into agent(agent_id, preferred_name_string,sameas_guid,yearofbirth,yearofdeath,abbreviated_name_string,prefix,suffix,first_name,middle_names,family_names)
+values (4,'Jakob Friedrich Ehrhart','https://viaf.org/viaf/3221377',1742,1795,'Ehrh.','','','Jakob','Friedrich','Ehrhart');
 insert into agentname(agent_id, type, name) values (4,'full name','Jakob Friedrich Ehrhart');
 insert into agentname(agent_id, type, name) values (4,'also known as','Friedrich Ehrhart');
 insert into agentname(agent_id, type, name) values (4,'standard botanical abbreviation','Ehrh.');
 insert into agentlink (agent_id, type, link, text) values (4,'wiki','https://en.wikipedia.org/wiki/Ehrh.','Wikipedia entry');
 
-insert into agent(agent_id, preferred_name_string,sameas_guid,yearofbirth,yearofdeath,abbreviated_name_string,prefix,suffix,first_name,middle_names,family_names) 
-       values (5,'Erik Acharius','https://viaf.org/viaf/51806870',1757,1819,'Ach.','','','Erik','','Acharius');
+insert into agent(agent_id, preferred_name_string,sameas_guid,yearofbirth,yearofdeath,abbreviated_name_string,prefix,suffix,first_name,middle_names,family_names)
+values (5,'Erik Acharius','https://viaf.org/viaf/51806870',1757,1819,'Ach.','','','Erik','','Acharius');
 insert into agentname(agent_id, type, name) values (5,'full name','Erik Acharius');
 insert into agentname(agent_id, type, name) values (5,'standard botanical abbreviation','Ach.');
 insert into agentlink (agent_id, type, link, text) values (5,'wiki','https://en.wikipedia.org/wiki/Ach.','Wikipedia entry');
 
 insert into agent(agent_id, preferred_name_string,sameas_guid,yearofbirth,yearofdeath,abbreviated_name_string,prefix,suffix,first_name,middle_names,family_names) 
-       values (6,'Edward Tuckerman','https://viaf.org/viaf/59861375',1817,1886,'Tuckerman','','','Edward','','Tuckerman');
+values (6,'Edward Tuckerman','https://viaf.org/viaf/59861375',1817,1886,'Tuckerman','','','Edward','','Tuckerman');
 insert into agentname(agent_id, type, name) values (6,'full name','Edward Tuckerman');
 insert into agentname(agent_id, type, name) values (6,'standard botanical abbreviation','Tuckerman');
 insert into agentlink (agent_id, type, link, text) values (6,'wiki','https://en.wikipedia.org/wiki/Edward_Tuckerman','Wikipedia entry');
 
+
 -- Real taxa used in the example data
 
-insert into taxon (taxon_id, scientific_name, display_name, parent_id, parentage, taxontreedefitem_id, rank_id, nomenclatural_code) 
-       values (2, 'Fungi', 'Fungi', 1, '/1/2',2, 10, 'ICNafp');
-insert into taxon (taxon_id, scientific_name, display_name, parent_id, parentage, taxontreedefitem_id, rank_id, nomenclatural_code) 
-       values (3, 'Animalia', 'Animalia', 1, '/1/3',2, 10, 'ICZN');
-insert into taxon (taxon_id, scientific_name, display_name, parent_id, parentage, taxontreedefitem_id, rank_id, nomenclatural_code) 
-       values (4, 'Plantae', 'Plantae', 1, '/1/4',2, 10, 'ICNafp');
+-- changeset chicoreus:insert_taxon
+insert into taxon (taxon_id, scientific_name, display_name, parent_id, parentage, taxontreedefitem_id, rank_id, nomenclatural_code) values (null, 'Fungi', 'Fungi', 1, '/1/2',2, 10, 'ICNafp');
 
-insert into taxon (taxon_id, scientific_name, display_name, parent_id, parentage, taxontreedefitem_id, rank_id, nomenclatural_code) 
-       values (5, 'Parmeliaceae', 'Parmeliaceae', 2, '/1/2/5',14, 140, 'ICNafp');
-insert into taxon (taxon_id, scientific_name, display_name, parent_id, parentage, taxontreedefitem_id, rank_id, nomenclatural_code) 
-       values (6, 'Xanthoparmelia', '<em>Xanthoparmelia</em>', 5, '/1/2/5/6',17, 180, 'ICNafp');
-insert into taxon (taxon_id, scientific_name, display_name, parent_id, parentage, taxontreedefitem_id, rank_id, nomenclatural_code) 
-       values (7, 'Lichen', '<em>Lichen</em>', 2, '/1/2/7',17, 180, 'ICNafp');
+insert into taxon (taxon_id, scientific_name, display_name, parent_id, parentage, taxontreedefitem_id, rank_id, nomenclatural_code) values (null, 'Animalia', 'Animalia', 1, '/1/3',2, 10, 'ICZN');
+insert into taxon (taxon_id, scientific_name, display_name, parent_id, parentage, taxontreedefitem_id, rank_id, nomenclatural_code) values (null, 'Plantae', 'Plantae', 1, '/1/4',2, 10, 'ICNafp');
 
-insert into taxon (taxon_id, scientific_name, authorship, display_name, parent_id, parentage, taxontreedefitem_id, rank_id, nomenclatural_code, parauthor_agent_id, parexauthor_agent_id, author_agent_id, year_published, nomenclator_guid) 
-       values (8, 'Xanthoparmelia conspersa', '(Ehrh. ex Ach.) Hale', '<em>Xanthoparmelia conspersa</em> (Ehrh. ex Ach.) Hale', 6, '/1/2/5/6/8',19, 220, 'ICNafp',4,5,3, '(1974)', 'urn:lsid:indexfungorum.org:names:343884');
-insert into taxon (taxon_id, scientific_name, authorship, display_name, parent_id, parentage, taxontreedefitem_id, rank_id, nomenclatural_code, author_agent_id, exauthor_agent_id, year_published, accepted_taxon_id, nomenclator_guid) 
-       values (9, 'Lichen conspersus', 'Ehrh. ex Ach.', '<em>Lichen conspersus</em> Ehrh. ex Ach.', 7, '/1/2/7/9',19, 220, 'ICNafp',4,5,'1799 [1798]',7, 'urn:lsid:indexfungorum.org:names:393893');
+insert into taxon (taxon_id, scientific_name, display_name, parent_id, parentage, taxontreedefitem_id, rank_id, nomenclatural_code) values (null, 'Parmeliaceae', 'Parmeliaceae', 2, '/1/2/5',14, 140, 'ICNafp');
+insert into taxon (taxon_id, scientific_name, display_name, parent_id, parentage, taxontreedefitem_id, rank_id, nomenclatural_code) values (null, 'Xanthoparmelia', '<em>Xanthoparmelia</em>', 5, '/1/2/5/6',17, 180, 'ICNafp');
+insert into taxon (taxon_id, scientific_name, display_name, parent_id, parentage, taxontreedefitem_id, rank_id, nomenclatural_code) values (null, 'Lichen', '<em>Lichen</em>', 2, '/1/2/7',17, 180, 'ICNafp');
 
-insert into taxon (taxon_id, scientific_name, display_name, parent_id, parentage, taxontreedefitem_id, rank_id, nomenclatural_code) 
-       values (10, 'Fagaceae', 'Fagaceae', 4, '/1/4/10',14, 140, 'ICNafp');
-insert into taxon (taxon_id, scientific_name, display_name, parent_id, parentage, taxontreedefitem_id, rank_id, nomenclatural_code) 
-       values (11, 'Quercus', '<em>Quercus</em>', 10, '/1/4/10/11',17, 180, 'ICNafp');
-insert into taxon (taxon_id, scientific_name, authorship, display_name, parent_id, parentage, taxontreedefitem_id, rank_id, nomenclatural_code, author_agent_id, year_published, nomenclator_guid) 
-       values (12, 'Quercus alba', 'L.', '<em>Quercus alba</em> L.', 11, '/1/4/10/11/12',19, 220, 'ICNafp',2,'1753','urn:lsid:ipni.org:names:295763-1:1.2.2.1.1.3');
+insert into taxon (taxon_id, scientific_name, authorship, display_name, parent_id, parentage, taxontreedefitem_id, rank_id, nomenclatural_code, parauthor_agent_id, parexauthor_agent_id, author_agent_id, year_published, nomenclator_guid) values (null, 'Xanthoparmelia conspersa', '(Ehrh. ex Ach.) Hale', '<em>Xanthoparmelia conspersa</em> (Ehrh. ex Ach.) Hale', 6, '/1/2/5/6/8',19, 220, 'ICNafp',4,5,3, '(1974)', 'urn:lsid:indexfungorum.org:names:343884');
 
+insert into taxon (taxon_id, scientific_name, authorship, display_name, parent_id, parentage, taxontreedefitem_id, rank_id, nomenclatural_code, author_agent_id, exauthor_agent_id, year_published, accepted_taxon_id, nomenclator_guid) values (null, 'Lichen conspersus', 'Ehrh. ex Ach.', '<em>Lichen conspersus</em> Ehrh. ex Ach.', 7, '/1/2/7/9',19, 220, 'ICNafp',4,5,'1799 [1798]',7, 'urn:lsid:indexfungorum.org:names:393893');
 
-insert into taxon (taxon_id, scientific_name, display_name, parent_id, parentage, taxontreedefitem_id, rank_id, nomenclatural_code) 
-       values (13, 'Mollusca', 'Mollusca', 3, '/1/3/13', 4, 30, 'ICZN');
-insert into taxon (taxon_id, scientific_name, display_name, parent_id, parentage, taxontreedefitem_id, rank_id, nomenclatural_code) 
-       values (14, 'Gastropoda', 'Gastropoda', 13, '/1/3/13/14', 7, 60, 'ICZN');
-insert into taxon (taxon_id, scientific_name, display_name, parent_id, parentage, taxontreedefitem_id, rank_id, nomenclatural_code) 
-       values (15, 'Littorinidae', 'Littorinidae', 14, '/1/3/13/14/15', 14, 140, 'ICZN');
-insert into taxon (taxon_id, scientific_name, display_name, parent_id, parentage, taxontreedefitem_id, rank_id, nomenclatural_code) 
-       values (16, 'Littorina', 'Littorina', 15, '/1/3/13/14/15/16', 17, 180, 'ICZN');
-insert into taxon (taxon_id, scientific_name, authorship, display_name, parent_id, parentage, taxontreedefitem_id, rank_id, nomenclatural_code, parauthor_agent_id, year_published, nomenclator_guid) 
-       values (17, 'Littorina littorea', '(Linnaeus, 1758)', '<em>Littorina littorea</em> ()', 16, '/1/3/13/14/15/16/17', 19, 220, 'ICZN',2,'1758','urn:lsid:marinespecies.org:taxname:140262');
+insert into taxon (taxon_id, scientific_name, display_name, parent_id, parentage, taxontreedefitem_id, rank_id, nomenclatural_code) values (null, 'Fagaceae', 'Fagaceae', 4, '/1/4/10',14, 140, 'ICNafp');
+insert into taxon (taxon_id, scientific_name, display_name, parent_id, parentage, taxontreedefitem_id, rank_id, nomenclatural_code) values (null, 'Quercus', '<em>Quercus</em>', 10, '/1/4/10/11',17, 180, 'ICNafp');
+insert into taxon (taxon_id, scientific_name, authorship, display_name, parent_id, parentage, taxontreedefitem_id, rank_id, nomenclatural_code, author_agent_id, year_published, nomenclator_guid) values (null, 'Quercus alba', 'L.', '<em>Quercus alba</em> L.', 11, '/1/4/10/11/12',19, 220, 'ICNafp',2,'1753','urn:lsid:ipni.org:names:295763-1:1.2.2.1.1.3');
+
+insert into taxon (taxon_id, scientific_name, display_name, parent_id, parentage, taxontreedefitem_id, rank_id, nomenclatural_code) values (null, 'Mollusca', 'Mollusca', 3, '/1/3/13', 4, 30, 'ICZN');
+insert into taxon (taxon_id, scientific_name, display_name, parent_id, parentage, taxontreedefitem_id, rank_id, nomenclatural_code) values (null, 'Gastropoda', 'Gastropoda', 13, '/1/3/13/14', 7, 60, 'ICZN');
+insert into taxon (taxon_id, scientific_name, display_name, parent_id, parentage, taxontreedefitem_id, rank_id, nomenclatural_code) values (null, 'Littorinidae', 'Littorinidae', 14, '/1/3/13/14/15', 14, 140, 'ICZN');
+insert into taxon (taxon_id, scientific_name, display_name, parent_id, parentage, taxontreedefitem_id, rank_id, nomenclatural_code) values (null, 'Littorina', 'Littorina', 15, '/1/3/13/14/15/16', 17, 180, 'ICZN');
+insert into taxon (taxon_id, scientific_name, authorship, display_name, parent_id, parentage, taxontreedefitem_id, rank_id, nomenclatural_code, parauthor_agent_id, year_published, nomenclator_guid) values (null, 'Littorina littorea', '(Linnaeus, 1758)', '<em>Littorina littorea</em> ()', 16, '/1/3/13/14/15/16/17', 19, 220, 'ICZN',2,'1758','urn:lsid:marinespecies.org:taxname:140262');
 
 -- Real geographies used in the example data 
+-- changeset chicoreus:insert_geography
+insert into geography (geography_id, name, fullname, rank_id, parent_id, parentage, guid, geographytreedef_id, geographytreedefitem_id) values (1, 'Earth', 'Earth', 0, null, '/1', 'http://sws.geonames.org/6295630/',1,1);
+insert into geography (geography_id, name, fullname, rank_id, parent_id, parentage, guid, geographytreedef_id, geographytreedefitem_id) values (2, 'Europe', 'Europe', 100, 1, '/1/2', 'http://vocab.getty.edu/tgn/1000003',1,2);
+insert into geography (geography_id, name, fullname, rank_id, parent_id, parentage, guid, geographytreedef_id, geographytreedefitem_id) values (3, 'United Kingdom', 'United Kingdom', 200, 2, '/1/2/3', 'http://sws.geonames.org/2635167/',1,6);
+insert into geography (geography_id, name, fullname, rank_id, parent_id, parentage, guid, geographytreedef_id, geographytreedefitem_id) values (4, 'Wales', 'Wales', 260, 3, '/1/2/3/4', 'http://sws.geonames.org/2634895/',1,11);
+insert into geography (geography_id, name, fullname, rank_id, parent_id, parentage, guid, geographytreedef_id, geographytreedefitem_id) values (5, 'Cardiff', 'Wales: Cardiff', 500, 4, '/1/2/3/4/5','http://sws.geonames.org/2653822',1,30);
 
-insert into geography (geography_id, name, fullname, rank_id, parent_id, parentage, guid, geographytreedef_id, geographytreedefitem_id) 
-       values (1, 'Earth', 'Earth', 0, null, '/1', 'http://sws.geonames.org/6295630/',1,1);
-insert into geography (geography_id, name, fullname, rank_id, parent_id, parentage, guid, geographytreedef_id, geographytreedefitem_id) 
-       values (2, 'Europe', 'Europe', 100, 1, '/1/2', 'http://vocab.getty.edu/tgn/1000003',1,2);
-insert into geography (geography_id, name, fullname, rank_id, parent_id, parentage, guid, geographytreedef_id, geographytreedefitem_id) 
-       values (3, 'United Kingdom', 'United Kingdom', 200, 2, '/1/2/3', 'http://sws.geonames.org/2635167/',1,6);
-insert into geography (geography_id, name, fullname, rank_id, parent_id, parentage, guid, geographytreedef_id, geographytreedefitem_id) 
-       values (4, 'Wales', 'Wales', 260, 3, '/1/2/3/4', 'http://sws.geonames.org/2634895/',1,11);
-insert into geography (geography_id, name, fullname, rank_id, parent_id, parentage, guid, geographytreedef_id, geographytreedefitem_id) 
-       values (5, 'Cardiff', 'Wales: Cardiff', 500, 4, '/1/2/3/4/5','http://sws.geonames.org/2653822',1,30);
+insert into geography (geography_id, name, fullname, rank_id, parent_id, parentage, guid, geographytreedef_id, geographytreedefitem_id) values (6, 'North America', 'North and Central America', 100, 1, '/1/6', 'http://vocab.getty.edu/tgn/1000001',1,2);
+insert into geography (geography_id, name, fullname, rank_id, parent_id, parentage, guid, geographytreedef_id, geographytreedefitem_id) values (7, 'United States', 'United States', 200, 6, '/1/6/7', 'http://www.geonames.org/6252001',1,6);
+insert into geography (geography_id, name, fullname, rank_id, parent_id, parentage, guid, geographytreedef_id, geographytreedefitem_id) values (8, 'New Hampshire', 'US: New Hampshire', 300, 7, '/1/6/7/8', 'http://www.geonames.org/5090174',1,14);
 
-insert into geography (geography_id, name, fullname, rank_id, parent_id, parentage, guid, geographytreedef_id, geographytreedefitem_id) 
-       values (6, 'North America', 'North and Central America', 100, 1, '/1/6', 'http://vocab.getty.edu/tgn/1000001',1,2);
-insert into geography (geography_id, name, fullname, rank_id, parent_id, parentage, guid, geographytreedef_id, geographytreedefitem_id) 
-       values (7, 'United States', 'United States', 200, 6, '/1/6/7', 'http://www.geonames.org/6252001',1,6);
-insert into geography (geography_id, name, fullname, rank_id, parent_id, parentage, guid, geographytreedef_id, geographytreedefitem_id) 
-       values (8, 'New Hampshire', 'US: New Hampshire', 300, 7, '/1/6/7/8', 'http://www.geonames.org/5090174',1,14);
-
-insert into geography (geography_id, name, fullname, rank_id, parent_id, parentage, guid, geographytreedef_id, geographytreedefitem_id) 
-       values (9, 'Atlantic', 'Atlantic Ocean', 100, 1, '/1/9', 'http://www.geonames.org/',1,32);
+insert into geography (geography_id, name, fullname, rank_id, parent_id, parentage, guid, geographytreedef_id, geographytreedefitem_id) values (9, 'Atlantic', 'Atlantic Ocean', 100, 1, '/1/9', 'http://www.geonames.org/',1,32);
 
 -- Example catalog number series and collections used in the example data.
-
+-- changeset chicoreus:insert_catalognumberseries
 insert into catalognumberseries (catalognumberseries_id, name) values (1,'Example:Botany Accession Numbers');
 insert into catalognumberseries (catalognumberseries_id, name) values (2,'Example:Zoology Catalog Numbers');
 
+-- changeset chicoreus:insert_collection
 insert into collection(collection_id, collection_name, institution_guid, institution_code, collection_code, website_iri, scope_id) values (1,'Example:Botany Department','example.com','example.com','Botany Department','http://example.com/',7);
 insert into collection(collection_id, collection_name, institution_guid, institution_code, collection_code, website_iri, scope_id) values (2,'Example:Mammalogy Department','example.com','example.com','Mammalogy Department','http://example.com/',3);
 insert into collection(collection_id, collection_name, institution_guid, institution_code, collection_code, website_iri, scope_id) values (3,'Example:Paleontology Department','example.com','example.com','Paleontology Department','http://example.com/',6);
@@ -106,11 +88,12 @@ insert into catnumseriescollection (catalognumberseries_id, collection_id) value
 insert into catnumseriescollection (catalognumberseries_id, collection_id) values (2,2);
 insert into catnumseriescollection (catalognumberseries_id, collection_id) values (2,3);
 
+-- changeset chicoreus:insert_accession
 insert into accession (accession_id, accessionnumber, remarks, scope_id) values (1,'1','Example default accession',1);
 
 -- The Examples: 
-
 -- Case 1, simple case, one unit, one organism, one part, one preparation.
+-- changeset chicoreus:insert_example_case1
 insert into locality (locality_id, verbatim_locality, specificlocality, remarks, geopolitical_geography_id, geographic_geography_id) values (1, 'Mt. Monadnock','Mount Monadnock', 'Example Locality',8,8);
 insert into collector (collector_id, verbatim_collector, etal, remarks) values (1, 'Tuckerman','et al.','Example collector');
 insert into eventdate (eventdate_id, verbatim_date, iso_date) values (1,'10 Jan, 1880','1880-01-10');
@@ -130,6 +113,7 @@ insert into identification (taxon_id, identifiableitem_id,is_current,determiner_
 
 -- Case 2, packet with two organisms (lichen on bark in packet), with the packet being the cataloged object,
 -- thus (one catalog number and two occurrences).
+-- changeset chicoreus:insert_example_case2
 insert into locality (locality_id, verbatim_locality, specificlocality, remarks, geopolitical_geography_id, geographic_geography_id) values (2, 'Mt. Adams','Mount Adams', 'Example Locality',8,8);
 insert into eventdate (eventdate_id, verbatim_date, iso_date) values (3,'10 Feb, 1882','1882-02-10');
 insert into collector (collector_id, agent_id, verbatim_collector, etal) values (2, 6, 'Tuckerman','');
@@ -151,6 +135,7 @@ insert into identification (taxon_id, identifiableitem_id,is_current,determiner_
 
 
 -- Case 3, lot of one organism but two preparations (with the preparations cataloged)
+-- changeset chicoreus:insert_example_case3
 insert into locality (locality_id, verbatim_locality, specificlocality, remarks, geopolitical_geography_id,geographic_geography_id) values (3, 'Cardiff Bay','Cardiff Bay', 'Example Locality',5,9);
 insert into eventdate (eventdate_id, verbatim_date, iso_date) values (6,'4-10 62','1962-04-10');
 insert into collector (collector_id, agent_id, verbatim_collector, etal) values (3, null, 'A. Jones','');

--- a/up.sh
+++ b/up.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-mvn clean install


### PR DESCRIPTION
Hi Paul,

**The following has been done:**

1. Using a **Makefile** for running maven ('mvn') and additional commands , instead of the up.sh-file
1.1 the standard way to do things
1.2 NB: you can create a MariaDB/MYSQL by sending arguments to a recipe in the makefile (see below)
  `$ make create_db DB_USER=my_user DB_PSW=my_password`

2. tables.sql has been updated.
2.1  divided into additional 'changesets' - making the footprint of each 'changeset' smaller (could even be made even smaller)
2.2 removed the table-attribute 'ENGINE=InnoDB' and   'DEFAULT CHARSET=utf8;'
2.3 NB. ENGINE=myisam is still there

3. exampledata.sql has been updated.
3.1 was lacking '-- liquibase formatted sql' and did not contain any 'changesets'

4. additional_alter_statements.sql has been added
4.1 four 'alter table' due to problems with insert from the exampledata.sql - lacking 'default'-value
4.2 NB : Should be moved to tables.sql

5. db.changelog-master.xml has been updated.
5.1 includes a reference to tables.sql + additional_alter_statements.sql + exampledata.sql

**Test:**
```
mysql> select count(*) from DATABASECHANGELOG;
+----------+
| count(*) |
+----------+
|      199 |
+----------+
1 row in set (0.00 sec)
```

**ToDo, when it comes to 'Running with Liquibase' **
1.  Add a recipe to the Makefile, for creating and dropping a postgreSQL-database
2.  is there any documentaion on functions.sql, optional.sql and triggers.sql - we are not using those right now
3. Go through the changesets in tables.sql , making them even more coherent